### PR TITLE
Python 3 Compatibility and Tkinter Geometry Fixes

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1,6 +1,8 @@
+import sys
+
 try:
-    from Tkinter import *
-    import tkFont
+    from tkinter import *
+    from tkinter import font as tkFont
 except ImportError as err:
     print("error: %s. Tkinter library is required for using the GUI." % err.message)
     sys.exit(1)
@@ -10,7 +12,7 @@ from AutomataTheory import *
 dotFound = isInstalled("dot")
 if dotFound:
     try:
-        import Image, ImageTk
+        from PIL import Image, ImageTk
     except ImportError as err:
         print("Notice: %s. The PIL library is required for displaying the graphs." % err.message)
         dotFound = False
@@ -37,8 +39,8 @@ class AutomataGUI:
         self.FrameSizeX  = int(ScreenSizeX * ScreenRatioX)
         self.FrameSizeY  = int(ScreenSizeY * ScreenRatioY)
         print(self.FrameSizeY, self.FrameSizeX)
-        FramePosX   = (ScreenSizeX - self.FrameSizeX)/2
-        FramePosY   = (ScreenSizeY - self.FrameSizeY)/2
+        FramePosX = int((ScreenSizeX - self.FrameSizeX)/2)
+        FramePosY = int((ScreenSizeY - self.FrameSizeY)/2)
         padX = 10
         padY = 10
         self.root.geometry("%sx%s+%s+%s" % (self.FrameSizeX,self.FrameSizeY,FramePosX,FramePosY))


### PR DESCRIPTION
### Changes Made

1. **Updated Tkinter imports for Python 3:**
   - Changed `from Tkinter import *` to `from tkinter import *`
   - Changed `import tkFont` to `from tkinter import font as tkFont`

2. **Updated PIL import syntax:**
   - Changed `import Image, ImageTk` to `from PIL import Image, ImageTk`

3. **Fixed Tkinter geometry error:**
   - Added explicit integer conversion to window position calculations:
     - Changed `FramePosX = (ScreenSizeX - self.FrameSizeX)/2` to `int((ScreenSizeX - self.FrameSizeX)/2)`
     - Changed `FramePosY = (ScreenSizeY - self.FrameSizeY)/2` to `int((ScreenSizeY - self.FrameSizeY)/2)`

### Why These Changes Were Needed

- The original code was written for Python 2 but is now being run on Python 3, where Tkinter module names are lowercase.
- Python 3 is more strict about types, and Tkinter geometry specification requires integer values, not floats.
- Modern PIL package requires imports through the PIL namespace.

### Testing

Successfully tested the application on Python 3.13. The application now launches correctly :)